### PR TITLE
Check for created_at property

### DIFF
--- a/django_statsd/clients/__init__.py
+++ b/django_statsd/clients/__init__.py
@@ -17,7 +17,7 @@ class StatsdClientProxy:
             return super().__getattribute__(name)
 
         refresh_cutoff = datetime.now() - timedelta(seconds=getattr(settings, 'STATSD_REFRESH_SECONDS', 120))
-        if self._client is None or self._client.created_at < refresh_cutoff:
+        if self._client is None or not hasattr(self._client, 'created_at') or self._client.created_at < refresh_cutoff:
             client = getattr(settings, 'STATSD_CLIENT', 'statsd.client')
             host = getattr(settings, 'STATSD_HOST', 'localhost')
             port = getattr(settings, 'STATSD_PORT', 8125)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ for req in requirements_test_file:
 # Became django-statsd-unleashed because django-statsd and django-statsd-mozilla are taken on Pypi. ;)
 setup(
     name='django-statsd-unleashed',
-    version='1.1.0',
+    version='1.1.1',
     url='https://github.com/vikingco/django-statsd',
     license='BSD',
     description='Django interface with statsd',


### PR DESCRIPTION
In rare cases, the `_client` is initialized without `created_at`
property. We don't want to crash on this.